### PR TITLE
fix: Dugout初期不良3件修正（#4 AP鈴仙外の世界枠・#5 正邪野手判定・#6 野手専念投手表示）

### DIFF
--- a/thbigmatome/app/controllers/api/v1/commissioner/dashboard_controller.rb
+++ b/thbigmatome/app/controllers/api/v1/commissioner/dashboard_controller.rb
@@ -127,7 +127,8 @@ class Api::V1::Commissioner::DashboardController < Api::V1::Commissioner::BaseCo
       team_memberships: [
         :season_rosters,
         { player_absences: :season },
-        { player: [ :cost_players, { player_cards: :player_card_defenses } ] }
+        { player: [ :cost_players ] },
+        { player_card: [ :card_set, :player_card_defenses ] }
       ]
     ).order(:name)
 
@@ -208,8 +209,9 @@ class Api::V1::Commissioner::DashboardController < Api::V1::Commissioner::BaseCo
 
         memberships.each do |tm|
           player = tm.player
-          card = player.player_cards.first
-          position = if card&.card_type == "pitcher"
+          card = tm.player_card
+          is_fielder_only = tm.selected_cost_type == "fielder_only_cost"
+          position = if card&.card_type == "pitcher" && !is_fielder_only
             "pitcher"
           else
             card&.player_card_defenses&.first&.position&.downcase
@@ -236,7 +238,8 @@ class Api::V1::Commissioner::DashboardController < Api::V1::Commissioner::BaseCo
             cooldown_until = cooldown_info[:cooldown_until]
           end
 
-          is_outside_world = !native_series.include?(player.series)
+          effective_series = card&.card_set&.series.presence || player.series
+          is_outside_world = effective_series.present? && !native_series.include?(effective_series)
 
           csv << [
             team.name,

--- a/thbigmatome/app/controllers/api/v1/pitcher_game_states_controller.rb
+++ b/thbigmatome/app/controllers/api/v1/pitcher_game_states_controller.rb
@@ -14,8 +14,10 @@ module Api
         pitcher_ids = if player_ids.present?
           player_ids
         else
+          # 登録カードが投手カードかつ野手専念契約でない選手のみ投手として扱う（#5 #6）
           @team.team_memberships
-               .joins(player: :player_cards)
+               .where.not(selected_cost_type: "fielder_only_cost")
+               .joins(:player_card)
                .where(player_cards: { is_pitcher: true })
                .distinct
                .pluck(:player_id)
@@ -61,8 +63,10 @@ module Api
         target_date = params[:date]&.to_date || Date.today
 
         # season_rostersベースでtarget_date時点の1軍メンバーを取得（現在のsquadではなく登録履歴で判定）
+        # 登録カードが投手カードかつ野手専念契約でない選手のみ（#5 #6）
         all_pitcher_memberships = @team.team_memberships
-          .joins(player: :player_cards)
+          .where.not(selected_cost_type: "fielder_only_cost")
+          .joins(:player_card)
           .where(player_cards: { card_type: "pitcher" })
           .includes(:player)
           .distinct

--- a/thbigmatome/app/controllers/api/v1/team_rosters_controller.rb
+++ b/thbigmatome/app/controllers/api/v1/team_rosters_controller.rb
@@ -19,7 +19,7 @@ module Api
         target_date = season.current_date
 
         # Fetch all team memberships for the team
-        team_memberships = team.team_memberships.preload(:season_rosters, :player_absences, player: [ :cost_players, { player_cards: :player_card_defenses } ])
+        team_memberships = team.team_memberships.preload(:season_rosters, :player_absences, player: [ :cost_players ], player_card: [ :card_set, :player_card_defenses ])
         start_date = season.season_schedules.minimum(:date)
 
         # Determine current squad for each player based on the latest SeasonRoster entry
@@ -34,23 +34,27 @@ module Api
 
           cooldown_info = calculate_cooldown_info(tm, target_date)
 
+          # 登録カード（player_card）を優先し、未設定の場合はplayer.seriesにフォールバック
+          pc = tm.player_card
+          effective_series = pc&.card_set&.series.presence || tm.player.series
+          is_fielder_only = tm.selected_cost_type == "fielder_only_cost"
+
           {
             team_membership_id: tm.id,
             player_id: tm.player.id,
             number: tm.player.number,
             player_name: tm.player.short_name,
-            handedness: tm.player.player_cards.first&.handedness,
-            position: (tm.player.player_cards.first&.card_type == "pitcher" ? "pitcher" : tm.player.player_cards.first&.player_card_defenses&.first&.position&.downcase),
+            handedness: pc&.handedness,
+            position: (pc&.card_type == "pitcher" && !is_fielder_only ? "pitcher" : pc&.player_card_defenses&.first&.position&.downcase),
             squad: squad_status,
             player_types: [],
-            selected_cost_type: tm.selected_cost_type, # Add selected cost type
-            cost: tm.player.cost_players.find { |pc| pc.cost_id == current_cost_list.id }.send(tm.selected_cost_type), # Assuming player has cost methods
-            # Add cooldown information if applicable
+            selected_cost_type: tm.selected_cost_type,
+            cost: tm.player.cost_players.find { |cp| cp.cost_id == current_cost_list.id }.send(tm.selected_cost_type),
             cooldown_until: cooldown_info[:cooldown_until],
             same_day_exempt: cooldown_info[:same_day_exempt],
-            is_outside_world: !native_series.include?(tm.player.series),
-            is_starter_pitcher: (tm.player.player_cards.first&.is_pitcher && tm.player.player_cards.first&.starter_stamina.present? && tm.player.player_cards.first&.starter_stamina >= 4) || false,
-            is_relief_only: (tm.player.player_cards.first&.is_pitcher && tm.player.player_cards.first&.is_relief_only) || false,
+            is_outside_world: effective_series.present? && !native_series.include?(effective_series),
+            is_starter_pitcher: (!is_fielder_only && pc&.is_pitcher && pc&.starter_stamina.present? && pc&.starter_stamina >= 4) || false,
+            is_relief_only: (!is_fielder_only && pc&.is_pitcher && pc&.is_relief_only) || false,
             **absence_info_for(tm, target_date)
           }
         end

--- a/thbigmatome/app/models/card_set.rb
+++ b/thbigmatome/app/models/card_set.rb
@@ -1,4 +1,11 @@
 class CardSet < ApplicationRecord
+  SERIES_BY_SET_TYPE = {
+    "annual"     => "touhou",
+    "hachinai61" => "hachinai",
+    "pm2026"     => "original",
+    "tamayomi2"  => "tamayomi"
+  }.freeze
+
   has_many :player_cards, dependent: :destroy
 
   validates :year, presence: true, numericality: { only_integer: true }

--- a/thbigmatome/app/models/team.rb
+++ b/thbigmatome/app/models/team.rb
@@ -65,9 +65,12 @@ class Team < ApplicationRecord
   # 1軍の外の世界枠選手（team_type に応じたネイティブ series 以外が外の世界枠）
   def outside_world_first_squad_memberships
     native = NATIVE_SERIES[team_type] || NATIVE_SERIES["normal"]
-    team_memberships.where(squad: "first")
-      .joins(:player)
-      .where.not(players: { series: native })
+    memberships = team_memberships.where(squad: "first")
+                                  .includes(:player, { player: :player_cards }, player_card: :card_set)
+    memberships.select do |tm|
+      effective_series = tm.player_card&.card_set&.series.presence || tm.player.series
+      effective_series.present? && !native.include?(effective_series)
+    end
   end
 
   # 外の世界枠: 最大4人チェック
@@ -88,9 +91,8 @@ class Team < ApplicationRecord
     ow_memberships = outside_world_first_squad_memberships
     return true if ow_memberships.size < OUTSIDE_WORLD_LIMIT
 
-    ow_with_cards = ow_memberships.includes(player: :player_cards)
-    has_pitcher = ow_with_cards.any? { |tm| tm.player.player_cards.any? { |pc| pc.card_type == "pitcher" } }
-    has_fielder = ow_with_cards.any? { |tm| tm.player.player_cards.any? { |pc| pc.card_type == "batter" } }
+    has_pitcher = ow_memberships.any? { |tm| tm.player.player_cards.any? { |pc| pc.card_type == "pitcher" } }
+    has_fielder = ow_memberships.any? { |tm| tm.player.player_cards.any? { |pc| pc.card_type == "batter" } }
 
     unless has_pitcher && has_fielder
       errors.add(:base, I18n.t("activerecord.errors.models.team.outside_world.balance_required"))

--- a/thbigmatome/db/migrate/20260405100000_add_series_to_card_sets.rb
+++ b/thbigmatome/db/migrate/20260405100000_add_series_to_card_sets.rb
@@ -1,0 +1,22 @@
+class AddSeriesToCardSets < ActiveRecord::Migration[8.1]
+  SERIES_BY_SET_TYPE = {
+    "annual"      => "touhou",
+    "hachinai61"  => "hachinai",
+    "pm2026"      => "original",
+    "tamayomi2"   => "tamayomi"
+  }.freeze
+
+  def up
+    add_column :card_sets, :series, :string
+
+    # Backfill existing card_sets from set_type
+    CardSet.find_each do |cs|
+      series = SERIES_BY_SET_TYPE[cs.set_type]
+      cs.update_column(:series, series) if series.present?
+    end
+  end
+
+  def down
+    remove_column :card_sets, :series
+  end
+end

--- a/thbigmatome/db/schema.rb
+++ b/thbigmatome/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_28_143743) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_05_100000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -137,6 +137,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_28_143743) do
     t.datetime "created_at", null: false
     t.boolean "is_outside_world", default: false, null: false
     t.string "name", null: false
+    t.string "series"
     t.string "set_type", default: "annual", null: false
     t.datetime "updated_at", null: false
     t.integer "year", null: false
@@ -481,8 +482,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_28_143743) do
     t.integer "steal_start"
     t.text "unique_traits"
     t.datetime "updated_at", null: false
+    t.string "variant"
+    t.index "card_set_id, player_id, card_type, COALESCE(variant, ''::character varying)", name: "index_player_cards_on_card_set_player_card_type_variant", unique: true
     t.index [ "batting_style_id" ], name: "index_player_cards_on_batting_style_id"
-    t.index [ "card_set_id", "player_id", "card_type" ], name: "index_player_cards_on_card_set_player_card_type", unique: true
     t.index [ "card_set_id" ], name: "index_player_cards_on_card_set_id"
     t.index [ "catcher_pitching_style_id" ], name: "index_player_cards_on_catcher_pitching_style_id"
     t.index [ "pinch_pitching_style_id" ], name: "index_player_cards_on_pinch_pitching_style_id"

--- a/thbigmatome/db/seeds/import_cards.rb
+++ b/thbigmatome/db/seeds/import_cards.rb
@@ -53,6 +53,7 @@ CSV.foreach("#{data_dir}/player_cards.csv", headers: true) do |row|
   card_set = CardSet.find_or_create_by!(name: defn[:name]) do |cs|
     cs.year     = defn[:year]
     cs.set_type = defn[:set_type]
+    cs.series   = CARD_SOURCE_SERIES[card_source]
   end
 
   if row["name"].blank?

--- a/thbigmatome/spec/factories/card_sets.rb
+++ b/thbigmatome/spec/factories/card_sets.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     sequence(:year) { |n| 2020 + n }
     sequence(:name) { |n| "Card Set #{n}" }
     set_type { "annual" }
+    series { CardSet::SERIES_BY_SET_TYPE[set_type] || "touhou" }
   end
 end

--- a/thbigmatome/spec/models/team_spec.rb
+++ b/thbigmatome/spec/models/team_spec.rb
@@ -261,6 +261,32 @@ RSpec.describe Team, type: :model do
         expect(team.outside_world_first_squad_memberships.size).to eq(0)
       end
     end
+
+    context "登録カードのcard_set.seriesを優先（#4 AP鈴仙修正）" do
+      let(:normal_team) { create(:team, team_type: "normal") }
+
+      it "player.series=touhouでもcard_set.series=originalなら外の世界枠になる" do
+        player = create(:player, series: "touhou")
+        original_card_set = create(:card_set, set_type: "pm2026", series: "original")
+        pc = create(:player_card, player: player, card_set: original_card_set, card_type: "batter")
+        create(:team_membership, team: normal_team, player: player, player_card: pc, squad: "first")
+        expect(normal_team.outside_world_first_squad_memberships.size).to eq(1)
+      end
+
+      it "player_card未設定の場合はplayer.seriesにフォールバックする" do
+        player = create(:player, series: "touhou")
+        create(:team_membership, team: normal_team, player: player, squad: "first")
+        expect(normal_team.outside_world_first_squad_memberships.size).to eq(0)
+      end
+
+      it "player.series=touhouでcard_set.series=touhouなら外の世界枠にならない" do
+        player = create(:player, series: "touhou")
+        touhou_card_set = create(:card_set, set_type: "annual", series: "touhou")
+        pc = create(:player_card, player: player, card_set: touhou_card_set, card_type: "batter")
+        create(:team_membership, team: normal_team, player: player, player_card: pc, squad: "first")
+        expect(normal_team.outside_world_first_squad_memberships.size).to eq(0)
+      end
+    end
   end
 
   # 外の世界枠バリデーション: player_player_typesテーブル廃止(cmd_511 Phase 2b)によりテスト削除

--- a/thbigmatome/spec/requests/api/v1/pitcher_game_states_spec.rb
+++ b/thbigmatome/spec/requests/api/v1/pitcher_game_states_spec.rb
@@ -129,8 +129,8 @@ RSpec.describe "Api::V1::PitcherGameStatesController", type: :request do
     describe "GET /api/v1/teams/:team_id/pitcher_game_states/fatigue_summary" do
       let(:card_set) { create(:card_set) }
       let(:pitcher_first) { create(:player, :pitcher) }
-      let!(:pitcher_first_card) { create(:player_card, player: pitcher_first, card_set: card_set, card_type: "pitcher") }
-      let!(:tm_first) { create(:team_membership, :first_squad, team: team, player: pitcher_first) }
+      let!(:pitcher_first_card) { create(:player_card, player: pitcher_first, card_set: card_set, card_type: "pitcher", is_pitcher: true) }
+      let!(:tm_first) { create(:team_membership, :first_squad, team: team, player: pitcher_first, player_card: pitcher_first_card) }
       # season_rostersベース判定のため、target_date以前に1軍登録されていることが必要
       let!(:season_roster_first) { create(:season_roster, team_membership: tm_first, squad: "first", registered_on: "2026-01-01") }
 
@@ -141,8 +141,8 @@ RSpec.describe "Api::V1::PitcherGameStatesController", type: :request do
 
       it "1軍投手のみ返す（squad=firstのみ）" do
         other_pitcher = create(:player, :pitcher)
-        create(:player_card, player: other_pitcher, card_set: card_set, card_type: "pitcher")
-        create(:team_membership, team: team, player: other_pitcher, squad: "second")
+        other_card = create(:player_card, player: other_pitcher, card_set: card_set, card_type: "pitcher", is_pitcher: true)
+        create(:team_membership, team: team, player: other_pitcher, player_card: other_card, squad: "second")
 
         get_fatigue_summary(date: "2026-03-10")
         ids = response.parsed_body.map { |e| e["player_id"] }
@@ -337,6 +337,75 @@ RSpec.describe "Api::V1::PitcherGameStatesController", type: :request do
         entry = response.parsed_body.find { |e| e["player_id"] == pitcher2.id }
         expect(entry["is_injured"]).to be true
       end
+    end
+  end
+
+  describe "GET /api/v1/teams/:team_id/pitcher_game_states（player_ids未指定：登録カード判定）" do
+    include_context "authenticated user"
+
+    let(:team) { create(:team) }
+
+    before { team.update!(user: user) }
+
+    def get_states_no_ids(date:)
+      get "/api/v1/teams/#{team.id}/pitcher_game_states",
+        params: { date: date }
+    end
+
+    # #5: 登録カードがバッターカードの選手は投手リストに含まれない
+    it "登録カードがbatterの選手は投手リストに含まれない（#5 正邪修正）" do
+      batter_player = create(:player)
+      card_set = create(:card_set)
+      batter_card = create(:player_card, player: batter_player, card_type: "batter", is_pitcher: false, card_set: card_set)
+      create(:team_membership, team: team, player: batter_player, player_card: batter_card, squad: "first")
+
+      get_states_no_ids(date: "2026-04-05")
+
+      player_ids = response.parsed_body.map { |e| e["player_id"] }
+      expect(player_ids).not_to include(batter_player.id)
+    end
+
+    # #5: 同一選手が投手カードと野手カードを持つ場合、登録カードで判定
+    it "同一選手の野手カードを登録した場合は投手リストに含まれない（#5 正邪修正）" do
+      two_way_player = create(:player)
+      card_set = create(:card_set)
+      # 投手カードも持つが、登録は野手カード
+      create(:player_card, player: two_way_player, card_type: "pitcher", is_pitcher: true, card_set: card_set)
+      batter_card = create(:player_card, player: two_way_player, card_type: "batter", is_pitcher: false, card_set: card_set)
+      create(:team_membership, team: team, player: two_way_player, player_card: batter_card, squad: "first")
+
+      get_states_no_ids(date: "2026-04-05")
+
+      player_ids = response.parsed_body.map { |e| e["player_id"] }
+      expect(player_ids).not_to include(two_way_player.id)
+    end
+
+    # #6: 野手専念契約の選手は投手リストに含まれない
+    it "fielder_only_cost契約の投手カード選手は投手リストに含まれない（#6 野崎夕姫修正）" do
+      two_way_player = create(:player)
+      card_set = create(:card_set)
+      pitcher_card = create(:player_card, player: two_way_player, card_type: "pitcher", is_pitcher: true, card_set: card_set)
+      create(:team_membership, team: team, player: two_way_player, player_card: pitcher_card,
+             squad: "first", selected_cost_type: "fielder_only_cost")
+
+      get_states_no_ids(date: "2026-04-05")
+
+      player_ids = response.parsed_body.map { |e| e["player_id"] }
+      expect(player_ids).not_to include(two_way_player.id)
+    end
+
+    # 正常系: 投手カード登録かつfielder_only以外は含まれる
+    it "登録カードがpitcherかつnormal_cost → 投手リストに含まれる" do
+      pitcher_player = create(:player)
+      card_set = create(:card_set)
+      pitcher_card = create(:player_card, player: pitcher_player, card_type: "pitcher", is_pitcher: true, card_set: card_set)
+      create(:team_membership, team: team, player: pitcher_player, player_card: pitcher_card,
+             squad: "first", selected_cost_type: "normal_cost")
+
+      get_states_no_ids(date: "2026-04-05")
+
+      player_ids = response.parsed_body.map { |e| e["player_id"] }
+      expect(player_ids).to include(pitcher_player.id)
     end
   end
 end

--- a/thbigmatome/spec/requests/api/v1/team_rosters_spec.rb
+++ b/thbigmatome/spec/requests/api/v1/team_rosters_spec.rb
@@ -111,9 +111,9 @@ RSpec.describe "Api::V1::TeamRosters", type: :request do
     context "pitcher fields (is_starter_pitcher / is_relief_only)" do
       it "returns is_starter_pitcher=true when pitcher has player_card with starter_stamina >= 4" do
         player = create(:player, :pitcher)
-        create(:team_membership, team: team, player: player, squad: "first", selected_cost_type: "normal_cost")
+        pc = create(:player_card, player: player, is_pitcher: true, starter_stamina: 5, is_relief_only: false)
+        create(:team_membership, team: team, player: player, player_card: pc, squad: "first", selected_cost_type: "normal_cost")
         create(:cost_player, cost: cost, player: player, normal_cost: 5)
-        create(:player_card, player: player, is_pitcher: true, starter_stamina: 5, is_relief_only: false)
 
         get "/api/v1/teams/#{team.id}/roster", as: :json
 
@@ -138,9 +138,9 @@ RSpec.describe "Api::V1::TeamRosters", type: :request do
 
       it "returns is_relief_only=true when player_card.is_relief_only is true" do
         player = create(:player, :pitcher)
-        create(:team_membership, team: team, player: player, squad: "first", selected_cost_type: "normal_cost")
+        pc = create(:player_card, player: player, is_pitcher: true, is_relief_only: true, starter_stamina: nil)
+        create(:team_membership, team: team, player: player, player_card: pc, squad: "first", selected_cost_type: "normal_cost")
         create(:cost_player, cost: cost, player: player, normal_cost: 5)
-        create(:player_card, player: player, is_pitcher: true, is_relief_only: true, starter_stamina: nil)
 
         get "/api/v1/teams/#{team.id}/roster", as: :json
 


### PR DESCRIPTION
## Summary

- **#4 AP鈴仙が外の世界枠にならない**: `card_sets`に`series`カラムを追加（migration）。外の世界枠判定を`player.series`優先→登録カードの`card_set.series`を優先し未設定時に`player.series`へフォールバックする方式に変更。AP鈴仙（PM2026/original）が正しく外の世界枠として扱われる。
- **#5 鬼人正邪が投手枠になっている**: pitcher_game_states_controllerとteam_rosters_controllerの投手判定を`player.player_cards.first`（全カード中の任意）→`team_membership.player_card`（登録カード）に修正。正邪の通常バージョン（野手カード登録）が投手リストから除外される。
- **#6 野手専念契約の選手が投手表示される**: `selected_cost_type=fielder_only_cost`の場合に投手表示・投手リストから除外。野崎夕姫が野手専念契約時に投手として表示されなくなる。

## 変更ファイル

- `db/migrate/20260405100000_add_series_to_card_sets.rb` — `card_sets.series`追加、既存データをset_typeから自動バックフィル
- `app/models/card_set.rb` — `SERIES_BY_SET_TYPE`定数追加
- `app/models/team.rb` — `outside_world_first_squad_memberships`を登録カードのcard_set.series優先に修正
- `db/seeds/import_cards.rb` — インポート時にcard_set.seriesを設定
- `app/controllers/api/v1/team_rosters_controller.rb` — 登録カード（player_card_id）使用、preload更新
- `app/controllers/api/v1/pitcher_game_states_controller.rb` — 登録カード判定 + fielder_only除外
- `app/controllers/api/v1/commissioner/dashboard_controller.rb` — 同上

## Test plan

- [x] 全977件テストPASS確認
- [x] `team_spec.rb` — AP鈴仙パターン（player.series=touhou + card_set.series=original → 外の世界枠）
- [x] `pitcher_game_states_spec.rb` — バッターカード登録選手・野手専念契約選手が投手リストに含まれないこと
- [x] `team_rosters_spec.rb` — is_starter_pitcher / is_relief_only が登録カードで正しく判定されること

Closes #4
Closes #5
Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)