### PR TITLE
fix(#7): 先発疲労P未設定時にデフォルト値3を適用（ルール§8.3）

### DIFF
--- a/thbigmatome/app/models/pitcher_game_state.rb
+++ b/thbigmatome/app/models/pitcher_game_state.rb
@@ -19,7 +19,9 @@ class PitcherGameState < ApplicationRecord
   # result_category 自動計算ロジック
   # game_result: "win" / "lose" / "draw" / "no_game"
   # pitchers_in_game: この試合のこのチームの投手総数（新規追加分含む）
-  # fatigue_p: カード記載疲労P（long_loss判定に使用）
+  # fatigue_p: カード記載の先発疲労P（long_loss判定に使用）。0/nil の場合はデフォルト3を適用（ルール§8.3）
+  DEFAULT_STARTER_FATIGUE_P = 3
+
   def self.calculate_result_category(role:, innings_pitched:, game_result:, pitchers_in_game:, fatigue_p: 0, decision: nil)
     return "no_game" if game_result == "no_game"
     return "normal" unless role == "starter"
@@ -27,9 +29,11 @@ class PitcherGameState < ApplicationRecord
     has_successor = pitchers_in_game > 1
     innings = innings_pitched.to_f
     fp = fatigue_p.to_i
+    # ルール§8.3: 先発疲労P未記載の投手が先発した場合、先発疲労P=3として扱う
+    fp = DEFAULT_STARTER_FATIGUE_P if fp == 0
     if innings > 0 && innings < 5 && has_successor && game_result == "lose" && decision == "L"
       "ko"
-    elsif game_result == "lose" && fp > 0 && innings > fp + 1
+    elsif game_result == "lose" && innings > fp + 1
       "long_loss"
     else
       "normal"

--- a/thbigmatome/spec/models/pitcher_game_state_spec.rb
+++ b/thbigmatome/spec/models/pitcher_game_state_spec.rb
@@ -110,8 +110,9 @@ RSpec.describe PitcherGameState, type: :model do
 
     describe "境界値テスト" do
       it "innings==5.0 は KO にならない（normal）" do
+        # KO条件（innings < 5）に該当しないことを確認。先発疲労Pを明示してlong_loss境界と分離
         expect(described_class.calculate_result_category(
-          role: "starter", innings_pitched: 5.0, game_result: "lose", pitchers_in_game: 2
+          role: "starter", innings_pitched: 5.0, game_result: "lose", pitchers_in_game: 2, fatigue_p: 6
         )).to eq("normal")
       end
 
@@ -154,6 +155,33 @@ RSpec.describe PitcherGameState, type: :model do
       it "負け試合で先発が4回降板 + decision=nil（リリーフがLを持つ） → KO にならない" do
         expect(described_class.calculate_result_category(
           role: "starter", innings_pitched: 4.0, game_result: "lose", pitchers_in_game: 2, decision: nil
+        )).to eq("normal")
+      end
+    end
+
+    context "先発疲労P未設定（fatigue_p=0）のときデフォルト値3を適用（ルール§8.3, #7修正）" do
+      it "fatigue_p未設定の先発が5.0回完投敗戦 → long_loss（デフォルト疲労P=3で判定）" do
+        expect(described_class.calculate_result_category(
+          role: "starter", innings_pitched: 5.0, game_result: "lose", pitchers_in_game: 1, fatigue_p: 0
+        )).to eq("long_loss")
+      end
+
+      it "fatigue_p未設定の先発が4.0回完投敗戦 → normal（3+1=4以下なのでlong_lossでない）" do
+        expect(described_class.calculate_result_category(
+          role: "starter", innings_pitched: 4.0, game_result: "lose", pitchers_in_game: 1, fatigue_p: 0
+        )).to eq("normal")
+      end
+
+      it "fatigue_p=1の先発（本来は先発疲労P未設定）でも デフォルト適用なし（1のまま判定）" do
+        # fatigue_p > 0 の場合はデフォルト不適用。ユーザーが明示的に入力した値を使用。
+        expect(described_class.calculate_result_category(
+          role: "starter", innings_pitched: 5.0, game_result: "lose", pitchers_in_game: 1, fatigue_p: 1
+        )).to eq("long_loss")
+      end
+
+      it "reliever は fatigue_p=0 でもデフォルト適用されない（normal のまま）" do
+        expect(described_class.calculate_result_category(
+          role: "reliever", innings_pitched: 3.0, game_result: "lose", pitchers_in_game: 1, fatigue_p: 0
         )).to eq("normal")
       end
     end

--- a/thbigmatome/spec/requests/api/v1/pitcher_appearances_spec.rb
+++ b/thbigmatome/spec/requests/api/v1/pitcher_appearances_spec.rb
@@ -197,7 +197,7 @@ RSpec.describe "Api::V1::PitcherAppearancesController", type: :request do
         expect(json["pitcher_appearance"]["result_category"]).to eq("long_loss")
       end
 
-      it "疲労P == 0 の場合 long_loss にならず normal になる" do
+      it "疲労P == 0（未設定）の場合 デフォルト3を適用して long_loss になる（ルール§8.3, #7修正）" do
         params = valid_params.deep_merge(pitcher_appearance: {
           role: "starter",
           innings_pitched: 8.0,
@@ -210,7 +210,8 @@ RSpec.describe "Api::V1::PitcherAppearancesController", type: :request do
 
         expect(response).to have_http_status(:created)
         json = response.parsed_body
-        expect(json["pitcher_appearance"]["result_category"]).to eq("normal")
+        # デフォルト疲労P=3が適用され、8.0 > 3+1=4 → long_loss
+        expect(json["pitcher_appearance"]["result_category"]).to eq("long_loss")
       end
 
       it "先発で通常パターンの場合 normal になる" do


### PR DESCRIPTION
## Summary

- ルール§8.3: 先発疲労P未記載の投手が先発した場合、先発疲労P=3として扱う
- `PitcherGameState.calculate_result_category` で `fatigue_p=0/nil` の場合に `DEFAULT_STARTER_FATIGUE_P=3` を適用するよう修正
- 修正前: `fatigue_p=0` で先発が完投敗戦しても `long_loss` にならなかった（fp+1=1回超えで発動していた）
- 修正後: デフォルト3適用により、5回超の完投敗戦で `long_loss` が正しくトリガーされる

## Changes

- `app/models/pitcher_game_state.rb`: `DEFAULT_STARTER_FATIGUE_P = 3` 定数追加、`fp == 0` 時にデフォルト適用
- `spec/models/pitcher_game_state_spec.rb`: 境界値テスト修正（`fatigue_p: 6` 明示）、§8.3デフォルト動作テスト4件追加
- `spec/requests/api/v1/pitcher_appearances_spec.rb`: `fatigue_p=0` 時のテストをnew behavior（`long_loss`）に更新

## Test plan

- [x] `bundle exec rspec` 974 examples, 0 failures
- [x] rubocop no offenses

Fixes #7