### PR TITLE
fix(ci): FE CIをyarnに切り替え（npm ci→yarn install --frozen-lockfile）

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,14 +91,14 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22'
-          cache: 'npm'
-          cache-dependency-path: thbigmatome-front/package-lock.json
+          cache: 'yarn'
+          cache-dependency-path: thbigmatome-front/yarn.lock
 
       - name: Install dependencies
-        run: npm ci
+        run: yarn install --frozen-lockfile
 
       - name: Run Vitest
-        run: npx vitest run
+        run: yarn vitest run
 
 # ============================================================
 # GitHub Secrets 設定ガイド


### PR DESCRIPTION
## Summary

- `cache: npm` → `cache: yarn`
- `cache-dependency-path: package-lock.json` → `yarn.lock`
- `npm ci` → `yarn install --frozen-lockfile`
- `npx vitest run` → `yarn vitest run`

## 背景

happy-dom のバージョン不一致（package.json: 20.8.9 / package-lock.json: 20.7.0）により `npm ci` が失敗。プロジェクトの yarn 統一方針に合わせ CI も yarn に切り替え。yarn.lock は既に正しいバージョン（20.8.9）を保持しているため変更不要。

## Test plan

- [ ] CI の Vitest (FE) ジョブが `yarn install --frozen-lockfile` で通ること
- [ ] `cache: yarn` / `yarn.lock` 参照が正しく設定されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)